### PR TITLE
Implement ExpandingIndexer

### DIFF
--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -233,7 +233,7 @@ class VariableWindowIndexer(BaseIndexer):
 
 
 class ExpandingIndexer(BaseIndexer):
-
+    """Calculate expanding window bounds."""
     def get_window_bounds(
         self,
         num_values: int = 0,
@@ -243,4 +243,4 @@ class ExpandingIndexer(BaseIndexer):
         closed: Optional[str] = None,
         win_type: Optional[str] = None,
     ) -> BeginEnd:
-        return np.zeros(num_values), np.arange(num_values)
+        return np.zeros(num_values, dtype=np.int64), np.arange(1, num_values + 1)

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -231,3 +231,17 @@ class VariableWindowIndexer(BaseIndexer):
                 end[i] -= 1
 
         return start, end
+
+
+class ExpandingIndexer(BaseIndexer):
+
+    def get_window_bounds(
+        self,
+        num_values: int = 0,
+        window_size: int = 0,
+        min_periods: Optional[int] = None,
+        center: Optional[bool] = None,
+        closed: Optional[str] = None,
+        win_type: Optional[str] = None,
+    ) -> BeginEnd:
+        return np.zeros(num_values), np.arange(num_values)

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -234,6 +234,7 @@ class VariableWindowIndexer(BaseIndexer):
 
 class ExpandingIndexer(BaseIndexer):
     """Calculate expanding window bounds."""
+
     def get_window_bounds(
         self,
         num_values: int = 0,

--- a/pandas/core/window/indexers.py
+++ b/pandas/core/window/indexers.py
@@ -244,4 +244,12 @@ class ExpandingIndexer(BaseIndexer):
         closed: Optional[str] = None,
         win_type: Optional[str] = None,
     ) -> BeginEnd:
+        """
+        Examples
+        --------
+        >>> ExpandingIndexer().get_window_bounds(10)
+
+        (array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+         array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10]))
+        """
         return np.zeros(num_values, dtype=np.int64), np.arange(1, num_values + 1)

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -395,6 +395,8 @@ class _Window(PandasObject, SelectionMixin):
         -------
         VariableWindowIndexer or FixedWindowIndexer
         """
+        if isinstance(self.window, BaseIndexer):
+            return self.window
         if self.is_freq_type:
             return VariableWindowIndexer(index=index_as_array)
         return FixedWindowIndexer(index=index_as_array)
@@ -480,9 +482,16 @@ class _Window(PandasObject, SelectionMixin):
                     center,
                     self.closed,
                 )
-                minimum_periods = _check_min_periods(
-                    window, _use_window(self.min_periods, window), len(values) + offset
-                )
+                if not isinstance(window, BaseIndexer):
+                    minimum_periods = _check_min_periods(
+                        window,
+                        _use_window(self.min_periods, window),
+                        len(values) + offset,
+                    )
+                else:
+                    minimum_periods = _check_min_periods(
+                        self.min_periods or 1, self.min_periods, len(values) + offset
+                    )
                 func = partial(  # type: ignore
                     func, begin=start, end=end, minimum_periods=minimum_periods
                 )

--- a/pandas/tests/window/test_custom_indexer.py
+++ b/pandas/tests/window/test_custom_indexer.py
@@ -1,5 +1,4 @@
 from pandas import Series
-
 from pandas.core.window.indexers import ExpandingIndexer
 import pandas.util.testing as tm
 

--- a/pandas/tests/window/test_custom_indexer.py
+++ b/pandas/tests/window/test_custom_indexer.py
@@ -20,6 +20,6 @@ def test_custom_indexer_validates(
 
 def test_expanding_indexer():
     s = Series(range(10))
-    result = s.rolling(ExpandingIndexer()).sum()
-    expected = s.expanding().sum()
+    result = s.rolling(ExpandingIndexer()).mean()
+    expected = s.expanding().mean()
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/window/test_custom_indexer.py
+++ b/pandas/tests/window/test_custom_indexer.py
@@ -1,5 +1,8 @@
 from pandas import Series
 
+from pandas.core.window.indexers import ExpandingIndexer
+import pandas.util.testing as tm
+
 
 def test_custom_indexer_validates(
     dummy_custom_indexer, win_types, closed, min_periods, center
@@ -13,3 +16,10 @@ def test_custom_indexer_validates(
         min_periods=min_periods,
         closed=closed,
     )
+
+
+def test_expanding_indexer():
+    s = Series(range(10))
+    result = s.rolling(ExpandingIndexer()).sum()
+    expected = s.expanding().sum()
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #26
- [x] tests added / passed
- [x] passes `black pandas`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This only work for `mean` so far since other operations currently merge calculating windows + aggregation.

Just implementing ExpandingIndexer for now. GroupbyIndexer will take more reshuffling of the internals.