### PR TITLE
Use parallel=True in rolling.apply

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1159,7 +1159,7 @@ class _Rolling_and_Expanding(_Rolling):
 
                         return impl
 
-                @numba.njit(parallel=True)
+                @numba.njit(nogil=True, parallel=True)
                 def roll_apply(
                     values: np.ndarray,
                     begin: np.ndarray,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -12,6 +12,7 @@ import numba
 import numpy as np
 
 import pandas._libs.window as libwindow
+import pandas.compat as compat
 from pandas.compat._optional import import_optional_dependency
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution, cache_readonly
@@ -1159,7 +1160,7 @@ class _Rolling_and_Expanding(_Rolling):
 
                         return impl
 
-                @numba.njit(nogil=True, parallel=True)
+                @numba.njit(nogil=True, parallel=not compat.is_platform_32bit())
                 def roll_apply(
                     values: np.ndarray,
                     begin: np.ndarray,

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1159,7 +1159,7 @@ class _Rolling_and_Expanding(_Rolling):
 
                         return impl
 
-                @numba.njit
+                @numba.njit(parallel=True)
                 def roll_apply(
                     values: np.ndarray,
                     begin: np.ndarray,
@@ -1167,7 +1167,9 @@ class _Rolling_and_Expanding(_Rolling):
                     minimum_periods: int,
                 ):
                     result = np.empty(len(begin))
-                    for i, (start, stop) in enumerate(zip(begin, end)):
+                    for i in numba.prange(len(result)):
+                        start = begin[i]
+                        stop = end[i]
                         window = values[start:stop]
                         count_nan = np.sum(np.isnan(window))
                         if len(window) - count_nan >= minimum_periods:


### PR DESCRIPTION
Gains an additional speedup from #29 

```
In [1]: s = pd.Series(range(10000))

In [2]: r = s.rolling(10)

In [3]: f = lambda x: np.sum(x) + 5

In [4]: %timeit r.apply(f, raw=False)
656 µs ± 112 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
