### PR TITLE
Add faster algorithm for fixed window rolling mean

### DIFF
--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -1253,7 +1253,11 @@ class _Rolling_and_Expanding(_Rolling):
     def mean(self, *args, **kwargs):
         nv.validate_window_func("mean", args, kwargs)
         kwargs["use_numba"] = True
-        return self._apply(methods.rolling_mean, "mean", **kwargs)
+        if is_integer(self.window) and not self.is_freq_type:
+            func = partial(methods.rolling_mean_fixed_window, window=self.window)
+        else:
+            func = methods.rolling_mean_generic
+        return self._apply(func, "mean", **kwargs)
 
     _shared_docs["median"] = dedent(
         """


### PR DESCRIPTION
As mentioned in https://github.com/twosigma/pandas/pull/33#issuecomment-537633213

```
In [1]: n = 1_000_000

In [2]: roll_fixed = pd.Series(range(n)).rolling(10)

In [3]: %timeit roll_fixed.mean()
23.6 ms ± 2.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
