### PR TITLE
WIP: Add online keyword in ewm constructor for EWM mean updates

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -140,6 +140,7 @@ from pandas.core.sorting import get_indexer_indexer
 from pandas.core.window import (
     Expanding,
     ExponentialMovingWindow,
+    OnlineExponentialMovingWindow,
     Rolling,
     Window,
 )
@@ -11094,7 +11095,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             self, min_periods=min_periods, center=center, axis=axis, method=method
         )
 
-    @final
     @doc(ExponentialMovingWindow)
     def ewm(
         self,
@@ -11107,10 +11107,25 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         ignore_na: bool_t = False,
         axis: Axis = 0,
         times: str | np.ndarray | FrameOrSeries | None = None,
-    ) -> ExponentialMovingWindow:
+        online: bool = False
+    ):
         axis = self._get_axis_number(axis)
         # error: Value of type variable "FrameOrSeries" of "ExponentialMovingWindow"
         # cannot be "object"
+        if online:
+            import_optional_dependency("numba")
+            return OnlineExponentialMovingWindow(
+                self,
+                com=com,
+                span=span,
+                halflife=halflife,
+                alpha=alpha,
+                min_periods=min_periods,
+                adjust=adjust,
+                ignore_na=ignore_na,
+                axis=axis,
+                times=times,
+            )
         return ExponentialMovingWindow(  # type: ignore[type-var]
             self,
             com=com,

--- a/pandas/core/window/__init__.py
+++ b/pandas/core/window/__init__.py
@@ -1,6 +1,7 @@
 from pandas.core.window.ewm import (  # noqa:F401
     ExponentialMovingWindow,
     ExponentialMovingWindowGroupby,
+    OnlineExponentialMovingWindow,
 )
 from pandas.core.window.expanding import (  # noqa:F401
     Expanding,

--- a/pandas/core/window/aggregators.py
+++ b/pandas/core/window/aggregators.py
@@ -1,0 +1,99 @@
+from typing import Dict, Optional
+import numpy as np
+
+from pandas.compat._optional import import_optional_dependency
+
+from pandas.core.util.numba_ import (
+    NUMBA_FUNC_CACHE,
+    get_jit_arguments,
+)
+
+
+def generate_online_numba_ewma_func(engine_kwargs: Optional[Dict[str, bool]]):
+    """
+    Generate a numba jitted groupby ewma function specified by values
+    from engine_kwargs.
+
+    Parameters
+    ----------
+    engine_kwargs : dict
+        dictionary of arguments to be passed into numba.jit
+
+    Returns
+    -------
+    Numba function
+    """
+    nopython, nogil, parallel = get_jit_arguments(engine_kwargs)
+
+    cache_key = (lambda x: x, "online_ewma")
+    if cache_key in NUMBA_FUNC_CACHE:
+        return NUMBA_FUNC_CACHE[cache_key]
+
+    numba = import_optional_dependency("numba")
+
+    @numba.jit(nopython=nopython, nogil=nogil, parallel=parallel)
+    def online_ewma(
+        values: np.ndarray,
+        deltas: np.ndarray,
+        minimum_periods: int,
+        old_wt_factor: float,
+        new_wt: float,
+        old_wt: float,
+        adjust: bool,
+        ignore_na: bool,
+    ):
+        result = np.empty(len(values))
+
+        weighted_avg = values[0]
+        nobs = int(not np.isnan(weighted_avg))
+        result[0] = weighted_avg if nobs >= minimum_periods else np.nan
+
+        for j in range(1, len(values)):
+            cur = values[j]
+            is_observation = not np.isnan(cur)
+            nobs += is_observation
+            if not np.isnan(weighted_avg):
+
+                if is_observation or not ignore_na:
+
+                    # note that len(deltas) = len(vals) - 1 and deltas[i] is to be
+                    # used in conjunction with vals[i+1]
+                    old_wt *= old_wt_factor ** deltas[j - 1]
+                    if is_observation:
+
+                        # avoid numerical errors on constant series
+                        if weighted_avg != cur:
+                            weighted_avg = (
+                                (old_wt * weighted_avg) + (new_wt * cur)
+                            ) / (old_wt + new_wt)
+                        if adjust:
+                            old_wt += new_wt
+                        else:
+                            old_wt = 1.0
+            elif is_observation:
+                weighted_avg = cur
+
+            result[j] = weighted_avg if nobs >= minimum_periods else np.nan
+
+        return result, old_wt
+
+    return online_ewma
+
+
+class EWMeanState:
+
+    def __init__(self, com, adjust, ignore_na):
+        alpha = 1. / (1. + com)
+        self.old_wt_factor = 1. - alpha
+        self.new_wt = 1. if adjust else alpha
+        self.old_wt = 1.
+        self.adjust = adjust
+        self.ignore_na = ignore_na
+
+    def run_ewm(self, weighted_avg, deltas, min_periods, ewm_func):
+        result, old_wt = ewm_func(weighted_avg, deltas, min_periods, self.old_wt_factor, self.new_wt, self.old_wt, self.adjust, self.ignore_na)
+        self.old_wt = old_wt
+        return result
+
+    def reset(self):
+        self.old_wt = 1

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -337,10 +337,6 @@ class ExponentialMovingWindow(BaseWindow):
         """
         return ExponentialMovingWindowIndexer()
 
-    def online(self):
-        import_optional_dependency("numba")
-        return OnlineExponentialMovingWindow(self.obj, **{attr: getattr(self, attr) for attr in self._attributes})
-
     @doc(
         _shared_docs["aggregate"],
         see_also=dedent(


### PR DESCRIPTION
```
In [6]: s = pd.Series([0, 1, 2, np.nan, 4])

In [7]: ewm_online = s.head(1).ewm(com=0.5, online=True)

In [8]: ewm_online
Out[8]: OnlineExponentialMovingWindow [com=0.5,min_periods=1,adjust=True,ignore_na=False,axis=0]

In [10]: ewm_online.mean()
Out[10]:
0    0.0
dtype: float64

In [11]: ewm_online.mean(update=s.iloc[1:4])
Out[11]:
1    0.750000
2    1.615385
3    1.615385
dtype: float64

In [12]: ewm_online.reset()

In [13]: ewm_online.mean()
Out[13]:
0    0.0
dtype: float64

In [14]: ewm_online.mean(update=s.tail(4))
Out[14]:
1    0.750000
2    1.615385
3    1.615385
4    3.670213
dtype: float64
```
